### PR TITLE
Disallow access to directory-listing

### DIFF
--- a/directory-listing/.htaccess
+++ b/directory-listing/.htaccess
@@ -1,0 +1,1 @@
+Options -Indexes


### PR DESCRIPTION
Even though in `htaccess.txt`, there's ` IndexIgnore "{LISTING_DIRECTORY}"` to disable indexing, someone still can access the directory by typing `domain/directory-listing` in the browser url.

This simple fix disables indexing the `directory-listing` itself.